### PR TITLE
fix workshop link on frontpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 Easily align objects in the editors.
 
 Steam Workshop 
-https://steamcommunity.com/sharedfiles/filedetails/?id=2954489716
+https://steamcommunity.com/sharedfiles/filedetails/?id=2961167812


### PR DESCRIPTION
I noticed that the hyperlink on the frontpage `README.md` doesn't point to the right mod.
This PR fixes that.