### PR TITLE
enable `hemtt launch`

### DIFF
--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -21,3 +21,12 @@ exclude = [
 
 [asc]
 enabled = true
+
+# Launched with `hemtt launch`
+[hemtt.launch.default]
+workshop = [
+    "450814997",  # CBA_A3's Workshop ID
+    "2369477168", # Advanced Developer Tools
+]
+parameters = [
+]


### PR DESCRIPTION
I wanted to take a look at #9 and was missing the config to launch the game with `hemtt launch` 
(which my muscle memory immediately wants to trigger after `hemtt build`).

So this PR adds the necessary config for this useful dev tool.

P.S.:
Since I saw [here](https://youtu.be/yGsNcOE9rsw?si=YFRtl6EARRSMsSOX&t=12) that you are using [Advanced Developer Tools](https://steamcommunity.com/sharedfiles/filedetails/?id=2369477168) I included it in the list of mods to launch with.