### PR TITLE
snap to terrain objects

### DIFF
--- a/addons/main/config/CfgUserActions.hpp
+++ b/addons/main/config/CfgUserActions.hpp
@@ -16,7 +16,7 @@ class CfgUserActions {
     };
     class GVAR(toggleTerrain) { // This class name is used for internal representation and also for the inputAction command.
         displayName = CSTRING(TerrainToggle);
-        tooltip = CSTRING(RotationToggle_Tooltip);
+        tooltip = CSTRING(TerrainToggle_Tooltip);
         onActivate = QUOTE([KEY_TERRAIN] call FUNC(handleInputToggle));		// _this is always true.
     };
     class GVAR(OpenAttributes) { // This class name is used for internal representation and also for the inputAction command.

--- a/addons/main/functions/fnc_snap.sqf
+++ b/addons/main/functions/fnc_snap.sqf
@@ -55,7 +55,7 @@ if (_snapPointsThis isEqualTo []) exitWith {systemChat "no snap points";};
 _snapPointsThis = _snapPointsThis apply {_object modelToWorldVisual _x};
 
 private _nearbyObjects = if (_snapTo isEqualType []) then {
-    nearestTerrainObjects [_object, [], 50 max (((boundingBox _object) # 2) * 2.5)] +
+    nearestTerrainObjects [_object, ["BUILDING", "BUNKER", "FENCE", "FORTRESS", "HOUSE", "MAIN ROAD", "POWER LINES", "QUAY", "RAILWAY", "ROAD", "ROCKS", "RUIN", "TRACK", "TRAIL", "WALL"], 50 max (((boundingBox _object) # 2) * 2.5)] +
     nearestObjects [_object, _snapTo, 50 max (((boundingBox _object) # 2) * 2.5)] - [_object];
 } else {
     [_snapTo]

--- a/addons/main/functions/fnc_snap.sqf
+++ b/addons/main/functions/fnc_snap.sqf
@@ -55,6 +55,7 @@ if (_snapPointsThis isEqualTo []) exitWith {systemChat "no snap points";};
 _snapPointsThis = _snapPointsThis apply {_object modelToWorldVisual _x};
 
 private _nearbyObjects = if (_snapTo isEqualType []) then {
+    nearestTerrainObjects [_object, [], 50 max (((boundingBox _object) # 2) * 2.5)] +
     nearestObjects [_object, _snapTo, 50 max (((boundingBox _object) # 2) * 2.5)] - [_object];
 } else {
     [_snapTo]


### PR DESCRIPTION
fixes #9

Maybe having the type filter completely open (`[]`) is a bit too much. 

`_nearbyObjects` then yields around 130 objects.
![image](https://github.com/user-attachments/assets/405ecba7-24b7-4979-91dc-5e245812e931)

Before this change I had only about 5 in the area where I tested.
![image](https://github.com/user-attachments/assets/4cbba6ee-ae82-4a45-9c93-ccd20611098d)

But it does not appear to cause any performance issues 
(`fnc_snap` isn't really called that often because it just happens upon user input).

After having this feature I had to realize that the fences at **Comms Bravo** don't appear to align perfectly anyways.
The original map creators probably didn't care too much because they left holes open anyways.
![image](https://github.com/user-attachments/assets/67d45c83-0792-4c56-a355-28274242713e)
The feature is still useful though to fill gaps quicker than doing it all manually.


