### PR TITLE
added underwater cable

### DIFF
--- a/addons/main/snap_points/a3.inc.sqf
+++ b/addons/main/snap_points/a3.inc.sqf
@@ -344,6 +344,8 @@
 ["\a3\structures_f\walls\new_wiredfence_10m_dam_f.p3d",[[-5,-0.29,-1.28837],[5.05,-0.29,-1.28837]]],
 ["\a3\structures_f\walls\new_wiredfence_pole_f.p3d",[[0,0,-1.27402],[0,0,-1.27402]]],
 
+["land_powercable_submarine_f",[[-0.070,-16.10,1.545],[0.033,15.93,-1.554]]],
+
 // Tanoan pillbox bunkers
 ["land_pillboxbunker_01_big_f",[[-5.74609,-2.09888,-0.77],[-3.1,-2.09888,-0.77],[4.3,-2.0979,-0.77]]],
 ["land_pillboxbunker_01_hex_f",[[0.461999,-1.08,-0.95],[0.461999,1.17,-0.95],[-2.12158,-2.9,-0.95],[-2.13525,2.9,-0.95]]],


### PR DESCRIPTION
PR will add underwater power cable.
<img width="1633" height="620" alt="image" src="https://github.com/user-attachments/assets/e829e667-852f-46c1-8007-9f6b01e485e9" />


`land_powercable_submarine_f` will only snap to other objects when the CBA option for snapping with use of keybind is used.
<img width="765" height="157" alt="image" src="https://github.com/user-attachments/assets/a3a758a7-7a5a-4bcd-91c3-10e0e19f0072" />
Reason seems to be that `land_powercable_submarine_f` never calls the `dragged3DEN` EH.


----
### Recommendation
`land_powercable_submarine_f` does not really fit nicely to itself. So use of other cables inbetween is recommended for looks.
<img width="1397" height="941" alt="image" src="https://github.com/user-attachments/assets/6f2b0243-b449-49c0-a0ec-85f7cef011e6" />
